### PR TITLE
Fix missing header in gcc10

### DIFF
--- a/generator/serializationcodegenerator.cpp
+++ b/generator/serializationcodegenerator.cpp
@@ -6,6 +6,8 @@
 #include <clang/AST/DeclFriend.h>
 #include <clang/AST/DeclTemplate.h>
 
+#include <iostream>
+
 using namespace std;
 
 namespace ReflectiveRapidJSON {


### PR DESCRIPTION
`#include <iostream>` is no longer included implicitly.

https://gcc.gnu.org/gcc-10/porting_to.html